### PR TITLE
chore: remove gemini-cli preview install from Dockerfile

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -53,9 +53,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
 
-# 7. Gemini CLI のインストール (preview指定)
-RUN npm install -g @google/gemini-cli@preview
-
 # # 8. キャッシュディレクトリの確保
 # ENV UV_CACHE_DIR=/root/.cache/uv
 


### PR DESCRIPTION
## Summary
- remove preview installation of @google/gemini-cli from build image
- keep Node.js/npm setup unchanged

## Why
- avoid installing an unnecessary preview CLI in the runner image

## Changes
- deleted the gemini-cli preview install RUN command in .build/Dockerfile
